### PR TITLE
Add CTK ingest service and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # neco
+
+Example project that periodically ingests articles from an API or RSS feed and stores them in a database.
+
+## Usage
+
+1. Set `DATABASE_URL` to your PostgreSQL or SQLite database.
+2. For API access, set `API_KEY` and `API_URL`. For RSS ingestion set `RSS_URL`.
+3. Run the scheduler:
+   ```bash
+   python scheduler.py
+   ```

--- a/models.py
+++ b/models.py
@@ -1,0 +1,29 @@
+import os
+
+from sqlalchemy import Column, DateTime, Integer, String, Text, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///articles.db")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()
+
+
+class Article(Base):
+    """Database model for stored articles."""
+
+    __tablename__ = "articles"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    content = Column(Text)
+    published_at = Column(DateTime)
+    source_url = Column(String, unique=True, nullable=False)
+
+
+def init_db() -> None:
+    """Initialize database tables."""
+    Base.metadata.create_all(engine)

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,27 @@
+import os
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from models import SessionLocal, init_db
+from services.ctk_ingest import ingest
+
+scheduler = BlockingScheduler()
+
+
+@scheduler.scheduled_job("interval", hours=1)
+def scheduled_ingest() -> None:
+    db = SessionLocal()
+    try:
+        ingest(
+            db_session=db,
+            api_key=os.getenv("API_KEY"),
+            api_url=os.getenv("API_URL"),
+            rss_url=os.getenv("RSS_URL"),
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    init_db()
+    scheduler.start()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package for CTK ingestion."""

--- a/services/ctk_ingest.py
+++ b/services/ctk_ingest.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+import feedparser
+from dateutil import parser as dateparser
+
+from models import Article
+
+
+def authenticate(api_key: str) -> requests.Session:
+    """Create an authenticated session for API access."""
+    session = requests.Session()
+    session.headers.update({"Authorization": f"Bearer {api_key}"})
+    return session
+
+
+def _parse_date(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return dateparser.parse(value)
+    except Exception:
+        return None
+
+
+def fetch_articles(
+    session: requests.Session,
+    api_url: Optional[str] = None,
+    rss_url: Optional[str] = None,
+) -> List[Dict[str, Optional[str]]]:
+    """Fetch articles either from JSON API or RSS feed."""
+    articles: List[Dict[str, Optional[str]]] = []
+
+    if api_url:
+        response = session.get(api_url)
+        response.raise_for_status()
+        data = response.json()
+        items = data.get("articles", data)
+        for item in items:
+            articles.append(
+                {
+                    "title": item.get("title"),
+                    "content": item.get("content") or item.get("description", ""),
+                    "published_at": _parse_date(item.get("published_at")),
+                    "source_url": item.get("url"),
+                }
+            )
+
+    if rss_url:
+        feed = feedparser.parse(rss_url)
+        for entry in feed.entries:
+            articles.append(
+                {
+                    "title": entry.get("title"),
+                    "content": entry.get("summary", ""),
+                    "published_at": _parse_date(entry.get("published")),
+                    "source_url": entry.get("link"),
+                }
+            )
+
+    return articles
+
+
+def store_articles(articles: List[Dict[str, Optional[str]]], db_session) -> None:
+    """Persist new articles into the database."""
+    for data in articles:
+        if not data.get("title") or not data.get("source_url"):
+            continue
+        exists = db_session.query(Article).filter_by(source_url=data["source_url"]).first()
+        if exists:
+            continue
+        article = Article(
+            title=data["title"],
+            content=data.get("content"),
+            published_at=data.get("published_at"),
+            source_url=data["source_url"],
+        )
+        db_session.add(article)
+    db_session.commit()
+
+
+def ingest(
+    db_session,
+    api_key: Optional[str] = None,
+    api_url: Optional[str] = None,
+    rss_url: Optional[str] = None,
+) -> None:
+    """High level helper to authenticate, fetch and store articles."""
+    session = authenticate(api_key) if api_url and api_key else requests.Session()
+    articles = fetch_articles(session, api_url=api_url, rss_url=rss_url)
+    store_articles(articles, db_session)


### PR DESCRIPTION
## Summary
- add service for authenticating, fetching, and storing CTK articles
- schedule periodic ingestion job
- persist articles with SQLAlchemy model

## Testing
- `python -m py_compile models.py services/ctk_ingest.py scheduler.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c57a1a3ca0832c9502aa00f59b741d